### PR TITLE
Implement FastMCP server for XPath prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Development Guidelines
+
+This repository follows modern Python best practices.
+
+* All new code **must** use explicit type hints and pass `mypy` type checking.
+* Format code with `black` and organize imports with `isort`.
+* Tests are written with `pytest`. Always run `pytest` before committing.
+* Keep functions short and well documented with docstrings.
+* Prefer standard library functionality over external dependencies unless required.
+
+Run the following commands before pushing changes:
+
+```bash
+isort .
+black .
+pytest
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# XPath Prompt MCP Server
+
+This repository contains a minimal [MCP](https://github.com/modelcontextprotocol) server built with the `mcp` Python package. The server exposes a single prompt describing best practices for generating XPath selectors for Android UI elements.
+
+## Requirements
+- Python 3.12+
+
+Install dependencies:
+
+```bash
+pip install mcp
+```
+
+## Running the server
+
+Clone the repository and start the server using the standard I/O transport:
+
+```bash
+git clone <repo-url>
+cd selector
+python server.py
+```
+
+The server will start in `stdio` mode. Use any compatible MCP client to request the `xpath_rules` prompt.

--- a/prompt.txt
+++ b/prompt.txt
@@ -1,0 +1,21 @@
+Generating XPath Selectors for Android UI Elements
+1.Prioritize Stable, Unique Attributes:
+Always use @resource-id and @content-desc as the primary basis for XPath selectors whenever they are available.
+2.Avoid Dependence on Text Attributes:
+Do not rely on the @text attribute or any values that may change, such as dynamic content, user data, or localized strings.
+3.Do Not Use Absolute Paths:
+Avoid writing full XPaths from the root node. Use relative paths (starting with //) to ensure selectors remain robust if the UI structure changes.
+4.Keep XPath Short and Maintainable:
+Create the shortest possible XPath that still uniquely identifies the element. Simpler selectors are easier to maintain and less likely to break.
+5.Avoid Indexes Whenever Possible:
+Do not select elements by their position or index. Use stable attributes for uniqueness instead.
+6.Avoid Unstable Attributes:
+Do not use attributes like @class, @bounds, or @package, as these can change across devices or app versions.
+7.Combine Multiple Stable Attributes if Needed:
+If a single attribute does not guarantee uniqueness, combine two or more stable attributes (such as @resource-id and @content-desc).
+8.Ensure XPath Uniqueness:
+Verify that each generated XPath uniquely matches only one element in the UI hierarchy.
+9.Use Partial Attribute Matching Only as a Last Resort:
+Use functions like contains() on stable attributes only when necessary, and only if the substring is guaranteed to be unique and consistent.
+10.Never Use Dynamic or Temporary Values:
+Avoid any attribute values that may change at runtime, such as randomly generated IDs, timestamps, or session-specific data.

--- a/server.py
+++ b/server.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+PROMPT_FILE = Path(__file__).with_name("prompt.txt")
+
+server = FastMCP(name="XPathPromptServer")
+
+
+@server.prompt(name="xpath_rules", title="XPath selector rules")
+def xpath_rules() -> str:
+    """Return rules for generating robust XPath selectors."""
+    return PROMPT_FILE.read_text()
+
+
+def main() -> None:
+    """Run the server using stdio transport."""
+    server.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,24 @@
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mcp.types import TextContent
+
+from server import PROMPT_FILE, server
+
+
+async def get_prompt_text() -> str:
+    result = await server.get_prompt("xpath_rules")
+    messages = result.messages
+    assert messages, "No messages returned"
+    content = messages[0].content
+    assert isinstance(content, TextContent)
+    return content.text
+
+
+def test_xpath_prompt() -> None:
+    expected = PROMPT_FILE.read_text()
+    text = asyncio.run(get_prompt_text())
+    assert expected == text


### PR DESCRIPTION
## Summary
- add server returning XPath rules using `mcp` FastMCP
- store XPath guideline prompt text
- document setup and running instructions
- enforce development guidelines in `AGENTS.md`
- provide tests verifying the prompt

## Testing
- `pytest -q`
- `mypy server.py tests/test_prompt.py`


------
https://chatgpt.com/codex/tasks/task_e_686d53fc951c83209e978f26ab472dd7