### PR TITLE
Add screen hierarchy tool

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import uiautomator2 as u2  # type: ignore
 from mcp.server.fastmcp import FastMCP
 
 PROMPT_FILE = Path(__file__).with_name("prompt.txt")
@@ -11,6 +12,21 @@ server = FastMCP(name="XPathPromptServer")
 def xpath_rules() -> str:
     """Return rules for generating robust XPath selectors."""
     return PROMPT_FILE.read_text()
+
+
+@server.tool(name="screen_hierarchy", title="Android screen hierarchy")
+def screen_hierarchy(device: str | None = None) -> str:
+    """Return the current screen hierarchy as an XML string.
+
+    Args:
+        device: Optional device URL or serial for ``uiautomator2.connect``.
+
+    Returns:
+        XML representation of the UI hierarchy.
+    """
+
+    d = u2.connect(device) if device else u2.connect()
+    return d.dump_hierarchy(compressed=False, pretty=True)
 
 
 def main() -> None:

--- a/tests/test_screen_hierarchy.py
+++ b/tests/test_screen_hierarchy.py
@@ -1,0 +1,28 @@
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mcp.types import TextContent
+
+from server import server
+
+
+async def call_tool() -> str:
+    fake_device = MagicMock()
+    fake_device.dump_hierarchy.return_value = "<hierarchy/>"
+    with patch("server.u2.connect", return_value=fake_device):
+        result = await server.call_tool("screen_hierarchy", {})
+    assert isinstance(result, tuple), "Unexpected tool result type"
+    content_list, _ = result
+    assert content_list, "No content returned"
+    content = content_list[0]
+    assert isinstance(content, TextContent)
+    return content.text
+
+
+def test_screen_hierarchy_tool() -> None:
+    text = asyncio.run(call_tool())
+    assert text == "<hierarchy/>"


### PR DESCRIPTION
## Summary
- add Android screen hierarchy tool using uiautomator2
- test the screen hierarchy tool

## Testing
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d59e8e9f48320b563bbe1ddcf72f6