### PR TITLE
Return parsed screen hierarchy

### DIFF
--- a/hierarchy.py
+++ b/hierarchy.py
@@ -1,0 +1,31 @@
+from typing import Any
+from xml.etree import ElementTree
+
+
+def parse_node(xml_node: ElementTree.Element) -> dict[str, Any]:
+    """Recursively parse ``xml_node`` into dictionaries."""
+
+    attrib = xml_node.attrib
+    children = [
+        parse_node(child)
+        for child in xml_node.findall("node")
+        if child.attrib.get("visible-to-user") == "true"
+    ]
+    node: dict[str, Any] = {
+        "index": int(attrib["index"]) if attrib.get("index") else None,
+        "package": attrib.get("package"),
+        "bounds": attrib.get("bounds"),
+        "class": attrib.get("class"),
+        "text": attrib.get("text"),
+        "resource-id": attrib.get("resource-id"),
+        "content-desc": attrib.get("content-desc"),
+        "children": children,
+    }
+    return {k: v for k, v in node.items() if v not in (None, [], {})}
+
+
+def parse_xml_to_tree(xml_path: str) -> list[dict[str, Any]]:
+    """Parse ``xml_path`` hierarchy string into a list of dictionaries."""
+
+    root = ElementTree.fromstring(xml_path)
+    return [parse_node(node) for node in root.findall("node")]

--- a/server.py
+++ b/server.py
@@ -1,7 +1,10 @@
 from pathlib import Path
+from typing import Any
 
 import uiautomator2 as u2  # type: ignore
 from mcp.server.fastmcp import FastMCP
+
+from hierarchy import parse_xml_to_tree
 
 PROMPT_FILE = Path(__file__).with_name("prompt.txt")
 
@@ -15,18 +18,19 @@ def xpath_rules() -> str:
 
 
 @server.tool(name="screen_hierarchy", title="Android screen hierarchy")
-def screen_hierarchy(device: str | None = None) -> str:
-    """Return the current screen hierarchy as an XML string.
+def screen_hierarchy(device: str | None = None) -> list[dict[str, Any]]:
+    """Return the current screen hierarchy as a list of dictionaries.
 
     Args:
         device: Optional device URL or serial for ``uiautomator2.connect``.
 
     Returns:
-        XML representation of the UI hierarchy.
+        Parsed representation of the UI hierarchy.
     """
 
     d = u2.connect(device) if device else u2.connect()
-    return d.dump_hierarchy(compressed=False, pretty=True)
+    xml = d.dump_hierarchy(compressed=False, pretty=True)
+    return parse_xml_to_tree(xml)
 
 
 def main() -> None:

--- a/tests/test_screen_hierarchy.py
+++ b/tests/test_screen_hierarchy.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -7,22 +8,35 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from mcp.types import TextContent
 
+from hierarchy import parse_xml_to_tree
 from server import server
 
+XML = """
+<hierarchy>
+    <node index='0' package='pkg' class='android.widget.TextView' text='foo' resource-id='res' content-desc='desc' bounds='[0,0][1,1]' visible-to-user='true'>
+        <node index='1' visible-to-user='false'/>
+        <node index='2' visible-to-user='true'/>
+    </node>
+</hierarchy>
+"""
 
-async def call_tool() -> str:
+
+async def call_tool() -> tuple[list[TextContent], dict[str, list[dict]]]:
     fake_device = MagicMock()
-    fake_device.dump_hierarchy.return_value = "<hierarchy/>"
+    fake_device.dump_hierarchy.return_value = XML
     with patch("server.u2.connect", return_value=fake_device):
         result = await server.call_tool("screen_hierarchy", {})
     assert isinstance(result, tuple), "Unexpected tool result type"
-    content_list, _ = result
+    content_list, structured = result
     assert content_list, "No content returned"
-    content = content_list[0]
-    assert isinstance(content, TextContent)
-    return content.text
+    for content in content_list:
+        assert isinstance(content, TextContent)
+    return content_list, structured
 
 
 def test_screen_hierarchy_tool() -> None:
-    text = asyncio.run(call_tool())
-    assert text == "<hierarchy/>"
+    contents, structured = asyncio.run(call_tool())
+    expected = parse_xml_to_tree(XML)
+    parsed = [json.loads(content.text) for content in contents]
+    assert parsed == expected
+    assert structured == {"result": expected}


### PR DESCRIPTION
## Summary
- parse screen hierarchy XML directly into dictionaries
- simplify `screen_hierarchy` tool to return parsed list
- adjust screen hierarchy tests for new structure

## Testing
- `isort . && black .`
- `mypy --ignore-missing-imports .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d5d52546083209b7984a4827f2070