### PR TITLE
Update README with client connection steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,18 @@ cd selector
 python server.py
 ```
 
-The server will start in `stdio` mode. Use any compatible MCP client to request the `xpath_rules` prompt.
+The server will start in `stdio` mode. Use any compatible MCP client to request
+the `xpath_selector_rules` prompt.
+
+## Connecting to a client
+
+Install the optional CLI tools and register the server with your MCP client:
+
+```bash
+pip install "mcp[cli]"
+mcp install server.py
+```
+
+After installation, start the server from the client and request the
+`xpath_selector_rules` prompt or call the `android_screen_hierarchy` tool as
+needed.

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -10,7 +10,7 @@ from server import PROMPT_FILE, server
 
 
 async def get_prompt_text() -> str:
-    result = await server.get_prompt("xpath_rules")
+    result = await server.get_prompt("xpath_selector_rules")
     messages = result.messages
     assert messages, "No messages returned"
     content = messages[0].content

--- a/tests/test_screen_hierarchy.py
+++ b/tests/test_screen_hierarchy.py
@@ -25,7 +25,7 @@ async def call_tool() -> tuple[list[TextContent], dict[str, list[dict]]]:
     fake_device = MagicMock()
     fake_device.dump_hierarchy.return_value = XML
     with patch("server.u2.connect", return_value=fake_device):
-        result = await server.call_tool("screen_hierarchy", {})
+        result = await server.call_tool("android_screen_hierarchy", {})
     assert isinstance(result, tuple), "Unexpected tool result type"
     content_list, structured = result
     assert content_list, "No content returned"


### PR DESCRIPTION
## Summary
- note how to register the server with a MCP client
- update tests to use current prompt and tool names

## Testing
- `isort .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d6b84399483209f730838b424c4fe