### PR TITLE
Convert prompt to tools and add Espresso selector guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Android XPath Selector Server
 
-This project implements a minimal [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) server that assists with building stable XPath selectors for Android user interfaces. The server exposes two capabilities:
+This project implements a minimal [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) server that assists with building stable selectors for Android user interfaces. The server exposes three tools:
 
-- **Prompt `xpath_selector_rules`** – Returns guidelines describing how to craft robust XPath expressions.
+- **Tool `xpath_selector_rules`** – Returns guidelines describing how to craft robust XPath expressions.
+- **Tool `espresso_selector_rules`** – Provides best practices for reliable Espresso selectors.
 - **Tool `android_screen_hierarchy`** – Connects to an Android device using `uiautomator2` and returns a structured representation of the current UI hierarchy.
 
 ## Requirements
@@ -25,7 +26,7 @@ cd selector
 python server.py
 ```
 
-The server will run in `stdio` mode. Any MCP-compatible client can request the prompt or invoke the hierarchy tool.
+The server will run in `stdio` mode. Any MCP-compatible client can invoke the provided tools.
 
 ## Development
 
@@ -55,4 +56,4 @@ For Claude Desktop, add an entry to `~/Library/Application Support/Claude/claude
 }
 ```
 
-After configuring, start the server from the client and use the provided prompt or tool as needed.
+After configuring, start the server from the client and use the provided tools as needed.

--- a/espresso_prompt.txt
+++ b/espresso_prompt.txt
@@ -1,0 +1,12 @@
+Selecting Elements with Espresso
+1. Prefer resource ID: use onView(withId(R.id.your_id)) whenever possible.
+2. Use content description for accessibility elements via withContentDescription.
+3. Avoid matching on text unless it is stable and localized strings are not a concern.
+4. Combine multiple matchers with allOf() to ensure uniqueness.
+5. Interact with scrollable containers using RecyclerViewActions or scrollTo().
+6. Avoid absolute view hierarchies; use withParent or isDescendantOfA sparingly.
+7. Wait for asynchronous operations with IdlingResource instead of sleeps.
+8. Write custom Matchers for complex cases and reuse them across tests.
+9. Keep selectors short and focused on stable attributes only.
+10. Validate that each selector matches a single view before using it in tests.
+

--- a/server.py
+++ b/server.py
@@ -6,15 +6,22 @@ from mcp.server.fastmcp import FastMCP
 
 from hierarchy import parse_xml_to_tree
 
-PROMPT_FILE = Path(__file__).with_name("prompt.txt")
+XPATH_PROMPT_FILE = Path(__file__).with_name("prompt.txt")
+ESPRESSO_PROMPT_FILE = Path(__file__).with_name("espresso_prompt.txt")
 
-server = FastMCP(name="XPathPromptServer")
+server = FastMCP(name="SelectorServer")
 
 
-@server.prompt(name="xpath_selector_rules", title="XPath selector rules")
+@server.tool(name="xpath_selector_rules", title="XPath selector rules")
 def xpath_selector_rules() -> str:
     """Return rules for generating robust XPath selectors."""
-    return PROMPT_FILE.read_text()
+    return XPATH_PROMPT_FILE.read_text()
+
+
+@server.tool(name="espresso_selector_rules", title="Espresso selector rules")
+def espresso_selector_rules() -> str:
+    """Return best practices for Espresso selectors."""
+    return ESPRESSO_PROMPT_FILE.read_text()
 
 
 @server.tool(name="android_screen_hierarchy", title="Android screen hierarchy")

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -6,19 +6,26 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from mcp.types import TextContent
 
-from server import PROMPT_FILE, server
+from server import ESPRESSO_PROMPT_FILE, XPATH_PROMPT_FILE, server
 
 
-async def get_prompt_text() -> str:
-    result = await server.get_prompt("xpath_selector_rules")
-    messages = result.messages
-    assert messages, "No messages returned"
-    content = messages[0].content
+async def get_tool_text(tool_name: str) -> str:
+    result = await server.call_tool(tool_name, {})
+    assert isinstance(result, tuple), "Unexpected tool result type"
+    content_list, _ = result
+    assert content_list, "No content returned"
+    content = content_list[0]
     assert isinstance(content, TextContent)
     return content.text
 
 
-def test_xpath_prompt() -> None:
-    expected = PROMPT_FILE.read_text()
-    text = asyncio.run(get_prompt_text())
+def test_xpath_rules_tool() -> None:
+    expected = XPATH_PROMPT_FILE.read_text()
+    text = asyncio.run(get_tool_text("xpath_selector_rules"))
+    assert expected == text
+
+
+def test_espresso_rules_tool() -> None:
+    expected = ESPRESSO_PROMPT_FILE.read_text()
+    text = asyncio.run(get_tool_text("espresso_selector_rules"))
     assert expected == text


### PR DESCRIPTION
## Summary
- replace `xpath_selector_rules` prompt with a tool
- add new `espresso_selector_rules` tool
- document new tools in README
- update tests for tool usage

## Testing
- `isort .`
- `black .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e25efd518832094b7e5b94c473bbc