### PR TITLE
Lower Python requirement and fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project implements a minimal [Model Context Protocol (MCP)](https://github.
 - **Tool `android_screen_hierarchy`** – Connects to an Android device using `uiautomator2` and returns a structured representation of the current UI hierarchy.
 
 ## Requirements
-- Python 3.12+
+ - Python 3.11+
 - An Android device accessible via `adb` for the hierarchy tool
 
 Install the package directly from GitHub:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "selector"
 version = "0.1.0"
 description = "Android UI Selector Server"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 license = {file = "LICENSE"}
 dependencies = [
     "mcp",
@@ -28,6 +28,6 @@ profile = "black"
 line-length = 88
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.11"
 ignore_missing_imports = true
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure package root is importable when tests are run without installation
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))


### PR DESCRIPTION
## Summary
- lower minimum Python version to 3.11
- update docs for Python 3.11
- ensure package is importable during tests

## Testing
- `isort .`
- `black .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68760bfeef208320b49c2aa758c4b039